### PR TITLE
Add "divider" Node type

### DIFF
--- a/navutils/menu.py
+++ b/navutils/menu.py
@@ -38,7 +38,7 @@ class Node(object):
 
     parent = None
 
-    def __init__(self, id, label, pattern_name=None, url=None, weight=0, title=None,
+    def __init__(self, id, label, pattern_name=None, url=None, divider=False, weight=0, title=None,
                  template='navutils/node.html', children=[], css_class=None, submenu_css_class=None,
                  reverse_kwargs=[], attrs={}, link_attrs={}, context={}, **kwargs):
         """
@@ -47,6 +47,7 @@ class Node(object):
         :param str pattern_name: the name of a django url, such as `myapp:index` to use
         as a link for the node. It will be automatically reversed.
         :param str url: a URL to use as a link for the node
+        :parma bool divider: node is a divider - url and pattern_name are ignored; could be header if label is provided
         :param int weight: The importance of the node. Higher is more\
         important, default to ``0``.
         :param list reverse_kwargs: A list of strings that the pattern_name will\
@@ -68,12 +69,15 @@ class Node(object):
         """
         if pattern_name and url:
             raise ValueError('MenuNode accepts either a url or a pattern_name arg, but not both')
-        if pattern_name is None and url is None:
+        if pattern_name is None and url is None and not divider:
             raise ValueError('MenuNode needs either a url or a pattern_name arg')
+        if divider and (pattern_name or url):
+            raise ValueError('MenuNode divider should have neither url nor pattern_name args')
 
         self._id = id
         self.pattern_name = pattern_name
         self.url = url
+        self.is_divider = divider
         self.label = label
         self.weight = weight
         self.template = template

--- a/navutils/templates/navutils/node.html
+++ b/navutils/templates/navutils/node.html
@@ -3,7 +3,9 @@
 <li
     class="{% block node_class %}menu-item{% if node.css_class %} {% render_nested node.css_class %}{% endif %}{% if is_current %} {% render_nested menu_config.CURRENT_MENU_ITEM_CLASS %}{% endif %}{% if has_current %} {% render_nested menu_config.CURRENT_MENU_ITEM_PARENT_CLASS %}{% endif %}{% if viewable_children %} has-children has-dropdown{% endif %}{% endblock %}"
     {% for attr, value in node.attrs.items %} {% render_nested attr %}="{% render_nested value %}"{% endfor %}>
-    <a href="{% render_nested node.get_url %}"{% for attr, value in node.link_attrs.items %} {% render_nested attr %}="{% render_nested value %}"{% endfor %}>{% block node_label %}{% render_nested node.label %}{% endblock %}</a>
+    {% if not node.is_divider %}<a %}%}="{% render_nested value %}" %} attr attr, endfor for href="{% render_nested node.get_url %}" in node.link_attrs.items render_nested value{% {% {%>{% endif %}
+        {% block node_label %}{% render_nested node.label %}{% endblock %}
+    {% if not node.is_divider %}</a>{% endif %}
     {% if viewable_children %}
         <ul class="{% block submenu_class %}sub-menu dropdown{% if node.submenu_css_class %} {% render_nested node.submenu_css_class %}{% endif %}{% endblock %}">
             {% for children_node in viewable_children %}

--- a/navutils/templates/navutils/node.html
+++ b/navutils/templates/navutils/node.html
@@ -3,7 +3,7 @@
 <li
     class="{% block node_class %}menu-item{% if node.css_class %} {% render_nested node.css_class %}{% endif %}{% if is_current %} {% render_nested menu_config.CURRENT_MENU_ITEM_CLASS %}{% endif %}{% if has_current %} {% render_nested menu_config.CURRENT_MENU_ITEM_PARENT_CLASS %}{% endif %}{% if viewable_children %} has-children has-dropdown{% endif %}{% endblock %}"
     {% for attr, value in node.attrs.items %} {% render_nested attr %}="{% render_nested value %}"{% endfor %}>
-    {% if not node.is_divider %}<a %}%}="{% render_nested value %}" %} attr attr, endfor for href="{% render_nested node.get_url %}" in node.link_attrs.items render_nested value{% {% {%>{% endif %}
+    {% if not node.is_divider %}<a href="{% render_nested node.get_url %}"{% for attr, value in node.link_attrs.items %} {% render_nested attr %}="{% render_nested value %}"{% endfor %}>{% endif %}
         {% block node_label %}{% render_nested node.label %}{% endblock %}
     {% if not node.is_divider %}</a>{% endif %}
     {% if viewable_children %}

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -47,11 +47,22 @@ class NodeTest(BaseTestCase):
 
         self.assertEqual(node.get_url(), '/')
 
+    def test_menu_node_detects_misconfiguration(self):
+        with self.assertRaises(ValueError):
+            menu.Node('test', 'Test')
+        with self.assertRaises(ValueError):
+            menu.Node('test', 'Test', pattern_name='index', url='/')
+        with self.assertRaises(ValueError):
+            menu.Node('test', 'Test', divider=True, pattern_name='index')
 
-    # def test_menu_node_allows_django_pattern_name_with_kwargs(self):
-    #     node = menu.Node('test', 'Test', pattern_name='category', reverse_kwargs=['slug'])
-    #
-    #     self.assertEqual(node.get_url(slug='test'), '/blog/category/test')
+    def test_menu_node_divider(self):
+        node = menu.Node('test', 'Test', divider=True)
+        self.assertTrue(node.is_divider)
+
+    def test_menu_node_allows_django_pattern_name_with_kwargs(self):
+        node = menu.Node('test', 'Test', pattern_name='category', reverse_kwargs=['slug'])
+
+        self.assertEqual(node.get_url(slug='test'), '/blog/category/test')
 
     def test_children_keep_reference_to_parent(self):
         child = menu.Node('c', 'Child', url='http://test.com/child')
@@ -238,6 +249,22 @@ class RenderNodeTest(BaseTestCase):
         self.assertHTMLEqual(
             output,
             '<li class="menu-item"><a href="http://test.com">Test</a></li>')
+
+    def test_render_node_template_tag_with_divider(self):
+        node = menu.Node('test', '', divider=True, css_class='divider')
+
+        output = navutils_tags.render_node({}, node=node, user=self.user)
+        self.assertHTMLEqual(
+            output,
+            '<li class="menu-item divider"></li>')
+
+    def test_render_node_template_tag_with_header(self):
+        node = menu.Node('test', 'Heading', divider=True, css_class='header')
+
+        output = navutils_tags.render_node({}, node=node, user=self.user)
+        self.assertHTMLEqual(
+            output,
+            '<li class="menu-item header">Heading</li>')
 
     def test_render_node_template_tag_with_embedded_template(self):
         node = menu.Node('test', '{{ 1|add:"2" }}', url='http://test.com')


### PR DESCRIPTION
Currently Node forces either a url or a pattern_name.  This does not allow for dividers and headers in menus, e.g.,  https://getbootstrap.com/docs/3.3/components/#dropdowns-headers

This patch adds a new kwarg to `Node.__init__` to allow for "divider" Nodes with no url -- using the label and css_class, one can create divider and header elements with this Node type.

Amended pre-condition checks in `Node.__init__` to enforce valid configuration of these 3 parameters.
Added unit tests to test pre-condition exceptions, is_divider behaviour, and node template tag output.