### PR TITLE
Order parent nodes if they have weight

### DIFF
--- a/navutils/menu.py
+++ b/navutils/menu.py
@@ -153,7 +153,7 @@ class Node(object):
         return self.id == current
 
     def has_current(self, current, viewable_children):
-        return any([child.is_current(current) for child in viewable_children])
+        return any([child.is_current(current) for child in viewable_children]) or any([child.has_current(current,child.children) for child in viewable_children])
 
 
 

--- a/navutils/templatetags/navutils_tags.py
+++ b/navutils/templatetags/navutils_tags.py
@@ -17,9 +17,10 @@ def render_menu(context, menu, **kwargs):
 
     max_depth = kwargs.get('max_depth', context.get('max_depth', 999))
     viewable_nodes = [node for node in menu.values() if node.is_viewable_by(user, context)]
-    print('viewable_nodes', viewable_nodes)
-    sorted_viewable_nodes = sorted(viewable_nodes,key=lambda i: i.weight, reverse=True)
-    print('sorted_viewable_nodes', sorted_viewable_nodes)
+    
+    # Also sort parent nodes if them have weight
+    viewable_nodes = sorted(viewable_nodes,key=lambda i: i.weight, reverse=True)
+
     if not viewable_nodes:
         return ''
 

--- a/navutils/templatetags/navutils_tags.py
+++ b/navutils/templatetags/navutils_tags.py
@@ -17,6 +17,7 @@ def render_menu(context, menu, **kwargs):
 
     max_depth = kwargs.get('max_depth', context.get('max_depth', 999))
     viewable_nodes = [node for node in menu.values() if node.is_viewable_by(user, context)]
+    print('viewable_nodes', viewable_nodes)
     if not viewable_nodes:
         return ''
 

--- a/navutils/templatetags/navutils_tags.py
+++ b/navutils/templatetags/navutils_tags.py
@@ -18,6 +18,8 @@ def render_menu(context, menu, **kwargs):
     max_depth = kwargs.get('max_depth', context.get('max_depth', 999))
     viewable_nodes = [node for node in menu.values() if node.is_viewable_by(user, context)]
     print('viewable_nodes', viewable_nodes)
+    sorted_viewable_nodes = sorted(viewable_nodes,key=lambda i: i.weight, reverse=True)
+    print('viewable_nodes', viewable_nodes)
     if not viewable_nodes:
         return ''
 

--- a/navutils/templatetags/navutils_tags.py
+++ b/navutils/templatetags/navutils_tags.py
@@ -19,7 +19,7 @@ def render_menu(context, menu, **kwargs):
     viewable_nodes = [node for node in menu.values() if node.is_viewable_by(user, context)]
     print('viewable_nodes', viewable_nodes)
     sorted_viewable_nodes = sorted(viewable_nodes,key=lambda i: i.weight, reverse=True)
-    print('viewable_nodes', viewable_nodes)
+    print('sorted_viewable_nodes', sorted_viewable_nodes)
     if not viewable_nodes:
         return ''
 


### PR DESCRIPTION
Ordering is only applied to child nodes, not to parent nodes. With this now render_menu tag will order also parent nodes before returning the menu. Also sets node as active if any of his subnodes is active.